### PR TITLE
set verbose option to passed parameter

### DIFF
--- a/caer/preprocess.py
+++ b/caer/preprocess.py
@@ -106,7 +106,7 @@ def preprocess_from_dir(DIR,
             class_path = join(DIR, item)
             class_label = classes.index(item)
             count = 0 
-            tens_list = list_images(class_path, use_fullpath=True, verbose=0)
+            tens_list = list_images(class_path, use_fullpath=True, verbose=verbose)
 
             for image_path in tens_list:
                 tens = imread(image_path, target_size=IMG_SIZE, rgb=True)


### PR DESCRIPTION
without this change I get the error below ""


---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
/media/brccabral/Data/PythonProjects/ImageAndVideo/simpsons.py in <module>
      31 # Create training data
----> 32 train = caer.preprocess_from_dir(DIR=char_path, classes=characters, channels=channels, IMG_SIZE=IMG_SIZE, isShuffle=True, verbose=True)

/media/brccabral/Data/PythonProjects/ImageAndVideo/venv/lib/python3.8/site-packages/caer/preprocess.py in preprocess_from_dir(DIR, classes, IMG_SIZE, channels, isShuffle, save_data, destination_filename, verbose)
    107             class_label = classes.index(item)
    108             count = 0
--> 109             tens_list = list_images(class_path, use_fullpath=True, verbose=0)
    110 
    111             for image_path in tens_list:

/media/brccabral/Data/PythonProjects/ImageAndVideo/venv/lib/python3.8/site-packages/caer/path/paths.py in list_images(DIR, recursive, use_fullpath, show_size, verbose)
     51 
     52     """
---> 53     return listdir(DIR=DIR, recursive=recursive, use_fullpath=use_fullpath, ext = _acceptable_image_formats, show_size=show_size, verbose=verbose)
     54 
     55 

/media/brccabral/Data/PythonProjects/ImageAndVideo/venv/lib/python3.8/site-packages/caer/path/paths.py in listdir(DIR, recursive, use_fullpath, ext, show_size, verbose)
    119 
    120     if not isinstance(verbose, bool):
--> 121         raise ValueError('verbose must be a boolean')
    122 
    123     dirs : list = []

ValueError: verbose must be a boolean