### PR TITLE
remove numpy warning

### DIFF
--- a/caer/preprocess.py
+++ b/caer/preprocess.py
@@ -127,7 +127,7 @@ def preprocess_from_dir(DIR,
             random.shuffle(data)
 
         # Converting to Numpy
-        data = np.array(data)
+        data = np.array(data, dtype=object)
 
         # Saves the Data set as a .npy file
         if save_data:


### PR DESCRIPTION
nothing fancy here, I just don't like unnecessary warnings.
This change removes this warning
```
~/PythonProjects/ImageAndVideo/venv/lib/python3.8/site-packages/caer/preprocess.py:130: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray
  data = np.array(data)
  
```